### PR TITLE
Upgrade jackson version due to security issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -286,12 +286,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.9.8</version>
+            <version>2.13.2</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10.7</version>
+            <version>2.13.2.2</version>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>


### PR DESCRIPTION
Better Cloud is running into issues due to jackson library incompatibility. In this context, checked that the versions we are using is an old version, and also has known vulnerabilities. Fixing it here.