### PR TITLE
Relocate gson and jackson dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,18 @@
                             </excludes>
                         </filter>
                     </filters>
+                    <shadedArtifactAttached>false</shadedArtifactAttached>
+                    <createDependencyReducedPom>true</createDependencyReducedPom>
+                    <relocations>
+                        <relocation>
+                            <pattern>com.fasterxml.jackson</pattern>
+                            <shadedPattern>rockset.com.fasterxml.jackson</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>com.google.gson</pattern>
+                            <shadedPattern>rockset.com.google.gson</shadedPattern>
+                        </relocation>
+                    </relocations>
                     <finalName>${project.artifactId}-${project.version}</finalName>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -342,11 +342,13 @@
                     <artifactId>junit</artifactId>
                 </exclusion>
             </exclusions>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <version>3.0.0</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>rockset-java</artifactId>
     <packaging>jar</packaging>
     <name>Rockset Java</name>
-    <version>0.9.1-snapshot</version>
+    <version>0.9.2-snapshot</version>
     <url>https://github.com/rockset/rockset-java-client</url>
     <description>The official Rockset Java client library</description>
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -310,15 +310,10 @@
             <artifactId>joda-time</artifactId>
             <version>2.10.1</version>
         </dependency>
-            <dependency>
-                <groupId>org.threeten</groupId>
-                <artifactId>threetenbp</artifactId>
-                <version>${threetenbp-version}</version>
-            </dependency>
         <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
-            <version>20180813</version>
+            <groupId>org.threeten</groupId>
+            <artifactId>threetenbp</artifactId>
+            <version>${threetenbp-version}</version>
         </dependency>
         <!-- test dependencies -->
         <dependency>
@@ -326,11 +321,6 @@
             <artifactId>junit</artifactId>
             <version>${junit-version}</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-model</artifactId>
-            <version>3.3.9</version>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>
@@ -367,6 +357,13 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+           <groupId>org.apache.commons</groupId>
+           <artifactId>commons-lang3</artifactId>
+           <version>${apache-commons-lang3-version}</version>
+           <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <properties>
@@ -377,9 +374,10 @@
         <swagger-core-version>1.5.18</swagger-core-version>
         <okhttp-version>2.7.5</okhttp-version>
         <gson-version>2.9.0</gson-version>
-            <threetenbp-version>1.3.5</threetenbp-version>
+        <threetenbp-version>1.3.5</threetenbp-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <junit-version>4.13.1</junit-version>
+        <apache-commons-lang3-version>3.12.0</apache-commons-lang3-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>


### PR DESCRIPTION
Disclaimer: I am not super excited about doing this. Customer wants dependency relocation to not conflict with their versions brought in by spring. In fact they want all our dependencies to be shaded, which I don't think is practical. Some other thoughts around this:

1. Don't create fat JAR for Rockset. This allows package dependencies to be brought in by the environment. Not sure how this plays with Rockset JDBC driver. Maybe we should package driver and client separately.
2. Anything else?