### PR TITLE
Allow consumers to manage dependencies as normal, and treat uberjar separately

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,18 +86,9 @@
                             </excludes>
                         </filter>
                     </filters>
-                    <shadedArtifactAttached>false</shadedArtifactAttached>
-                    <createDependencyReducedPom>true</createDependencyReducedPom>
-                    <relocations>
-                        <relocation>
-                            <pattern>com.fasterxml.jackson</pattern>
-                            <shadedPattern>rockset.com.fasterxml.jackson</shadedPattern>
-                        </relocation>
-                        <relocation>
-                            <pattern>com.google.gson</pattern>
-                            <shadedPattern>rockset.com.google.gson</shadedPattern>
-                        </relocation>
-                    </relocations>
+                    <shadedArtifactAttached>true</shadedArtifactAttached>
+                    <shadedClassifierName>uberjar</shadedClassifierName>
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
                     <finalName>${project.artifactId}-${project.version}</finalName>
                 </configuration>
             </plugin>
@@ -166,8 +157,7 @@
                         </goals>
                         <configuration>
                             <sources>
-                                <source>
-                                src/main/java</source>
+                                <source>src/main/java</source>
                             </sources>
                         </configuration>
                     </execution>


### PR DESCRIPTION
 We've been publishing uberjar to the maven repository. This is very troublesome, as it circumvent maven/gradle and other build tools dependency management techniques. Consumers of the library cannot apply their common techniques for managing dependencies to resolve version conflicts and such leading to a special kind of dependency hell.

This PR makes two changes:

First, it publishes a plain jar with a pom file that declares all dependencies to the Maven Central. Client consumers should use this by default with their build tools.

Second, it publishes an uberjar classifier jar with `-uber.jar` designation This jar is to be used when a standalone jar is needed (e.g. for Tableau JDBC connector or other visualization tools).

Inspecting the output:
```
-rw-r--r--   1 mahmood  staff   1.9M Apr 20 09:13 rockset-java-0.9.2-snapshot-javadoc.jar
-rw-r--r--   1 mahmood  staff   445K Apr 20 09:13 rockset-java-0.9.2-snapshot-sources.jar
-rw-r--r--   1 mahmood  staff    54K Apr 20 09:12 rockset-java-0.9.2-snapshot-tests.jar
-rw-r--r--   1 mahmood  staff   9.6M Apr 20 09:13 rockset-java-0.9.2-snapshot-uberjar.jar
-rw-r--r--   1 mahmood  staff   906K Apr 20 09:12 rockset-java-0.9.2-snapshot.jar
```