### PR TITLE
support rockset json model for timestamp, datetime, date and time for addDocs API

### DIFF
--- a/src/main/java/com/rockset/client/RocksetClient.java
+++ b/src/main/java/com/rockset/client/RocksetClient.java
@@ -110,8 +110,6 @@ public class RocksetClient {
     this.documents = documentsApi;
   }
 
-  public void setCustomDocuments(CustomDocumentsApi customDocumentsApi) {}
-
   public void setIntegrations(IntegrationsApi integrationsApi) {
     this.integrations = integrationsApi;
   }

--- a/src/main/java/com/rockset/client/RocksetClient.java
+++ b/src/main/java/com/rockset/client/RocksetClient.java
@@ -52,7 +52,7 @@ public class RocksetClient {
     this.apiKeys = new ApiKeysApi(this.apiClient);
     this.collections = new CollectionsApi(this.apiClient);
     this.customRolesBeta = new CustomRolesBetaApi(this.apiClient);
-    this.documents = new DocumentsApi(this.apiClient);
+    this.documents = new CustomDocumentsApi(this.apiClient);
     this.integrations = new IntegrationsApi(this.apiClient);
     this.organizations = new OrganizationsApi(this.apiClient);
     this.queries = new QueriesApi(this.apiClient);
@@ -109,6 +109,8 @@ public class RocksetClient {
   public void setDocuments(DocumentsApi documentsApi) {
     this.documents = documentsApi;
   }
+
+  public void setCustomDocuments(CustomDocumentsApi customDocumentsApi) {}
 
   public void setIntegrations(IntegrationsApi integrationsApi) {
     this.integrations = integrationsApi;

--- a/src/main/java/com/rockset/client/api/CustomDocumentsApi.java
+++ b/src/main/java/com/rockset/client/api/CustomDocumentsApi.java
@@ -1,0 +1,92 @@
+package com.rockset.client.api;
+
+import com.rockset.client.ApiClient;
+import com.rockset.client.model.AddDocumentsRequest;
+import com.rockset.client.model.AddDocumentsResponse;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+public class CustomDocumentsApi extends DocumentsApi {
+    static final String ROCKSET_TYPE = "__rockset_type";
+    static final String ROCKSET_VALUE = "value";
+
+    public CustomDocumentsApi(ApiClient apiClient) {
+        super(apiClient);
+    }
+
+    @Override
+    public AddDocumentsResponse add(String workspace, String collection, AddDocumentsRequest body) throws Exception {
+        for (Object doc : body.getData()) {
+            if (!(doc instanceof Map)) {
+                throw new IllegalArgumentException("Document is not a valid Map Object");
+            }
+            buildRocksetObject(doc);
+        }
+
+        return super.add(workspace, collection, body);
+    }
+
+    Object buildRocksetObject(Object doc) {
+        if (doc instanceof Map) {
+            final Map<String, Object> map = (Map) doc;
+            for (Map.Entry<String, Object> entry : map.entrySet()) {
+                Object value = buildRocksetObject(entry.getValue());
+                map.put(entry.getKey(), value);
+            }
+            return map;
+        } else if (doc instanceof List) {
+            final List<Object> list = (List) doc;
+            for (int i = 0; i < list.size(); i++) {
+                list.set(i, buildRocksetObject(list.get(i)));
+            }
+            return list;
+        } else if (doc instanceof Instant) {
+            Map<String, Object> timestamp = new HashMap<>();
+            timestamp.put(ROCKSET_TYPE, "timestamp");
+            timestamp.put(ROCKSET_VALUE, instantToTimestamp((Instant) doc));
+            return timestamp;
+        } else if (doc instanceof LocalDateTime) {
+           Map<String, Object> datetime = new HashMap<>();
+           datetime.put(ROCKSET_TYPE, "datetime");
+           // toString outputs in ISO-8601 format:
+            // uuuu-MM-dd'T'HH:mm
+            // uuuu-MM-dd'T'HH:mm:ss
+            // uuuu-MM-dd'T'HH:mm:ss.SSS
+            // uuuu-MM-dd'T'HH:mm:ss.SSSSSS
+            // uuuu-MM-dd'T'HH:mm:ss.SSSSSSSSS
+            datetime.put(ROCKSET_VALUE, ((LocalDateTime) doc).toString());
+           return datetime;
+        } else if (doc instanceof LocalDate) {
+            Map<String, Object> date = new HashMap<>();
+            date.put(ROCKSET_TYPE, "date");
+            // toString outputs in ISO-8601 format uuuu-MM-dd
+            date.put(ROCKSET_VALUE, ((LocalDate) doc).toString());
+            return date;
+        } else if (doc instanceof LocalTime) {
+            Map<String, Object> time = new HashMap<>();
+            time.put(ROCKSET_TYPE, "time");
+            // toString outputs in ISO-8601 format:
+            // HH:mm
+            // HH:mm:ss
+            // HH:mm:ss.SSS
+            // HH:mm:ss.SSSSSS
+            // HH:mm:ss.SSSSSSSSS
+            time.put(ROCKSET_VALUE, ((LocalTime) doc).toString());
+            return time;
+        }
+
+        return doc;
+    }
+
+    private long instantToTimestamp(Instant instant) {
+        return TimeUnit.SECONDS.toMicros(instant.getEpochSecond())
+                + TimeUnit.NANOSECONDS.toMicros(instant.getNano());
+    }
+}

--- a/src/main/java/com/rockset/client/api/CustomDocumentsApi.java
+++ b/src/main/java/com/rockset/client/api/CustomDocumentsApi.java
@@ -3,90 +3,130 @@ package com.rockset.client.api;
 import com.rockset.client.ApiClient;
 import com.rockset.client.model.AddDocumentsRequest;
 import com.rockset.client.model.AddDocumentsResponse;
-
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+/*
+ This class extends DocumentsApi which is auto-generated. This class
+ adds functionality to convert Java objects to rockset types like timestamp,
+ datetime, date and time.
+*/
 public class CustomDocumentsApi extends DocumentsApi {
-    static final String ROCKSET_TYPE = "__rockset_type";
-    static final String ROCKSET_VALUE = "value";
+  static final String ROCKSET_TYPE = "__rockset_type";
+  static final String ROCKSET_VALUE = "value";
 
-    public CustomDocumentsApi(ApiClient apiClient) {
-        super(apiClient);
+  public CustomDocumentsApi(ApiClient apiClient) {
+    super(apiClient);
+  }
+
+  @Override
+  public AddDocumentsResponse add(String workspace, String collection, AddDocumentsRequest body)
+      throws Exception {
+    for (Object doc : body.getData()) {
+      if (!(doc instanceof Map)) {
+        throw new IllegalArgumentException("Document is not a valid Map Object");
+      }
+      buildRocksetObject(doc);
     }
 
-    @Override
-    public AddDocumentsResponse add(String workspace, String collection, AddDocumentsRequest body) throws Exception {
-        for (Object doc : body.getData()) {
-            if (!(doc instanceof Map)) {
-                throw new IllegalArgumentException("Document is not a valid Map Object");
-            }
-            buildRocksetObject(doc);
-        }
+    return super.add(workspace, collection, body);
+  }
 
-        return super.add(workspace, collection, body);
+  Object buildRocksetObject(Object doc) {
+    if (doc instanceof Map) {
+      final Map<String, Object> map = (Map) doc;
+      for (Map.Entry<String, Object> entry : map.entrySet()) {
+        Object value = buildRocksetObject(entry.getValue());
+        map.put(entry.getKey(), value);
+      }
+      return map;
+    } else if (doc instanceof List) {
+      final List<Object> list = (List) doc;
+      for (int i = 0; i < list.size(); i++) {
+        list.set(i, buildRocksetObject(list.get(i)));
+      }
+      return list;
+    } else if (doc instanceof Set) {
+      // use hashset, order isn't doesn't matter here
+      Set<Object> modifiedSet = new HashSet<>();
+      for (Object element : (Set) doc) {
+        modifiedSet.add(buildRocksetObject(element));
+      }
+      return modifiedSet;
+    } else if (doc instanceof Instant) {
+      Map<String, Object> timestamp = new HashMap<>();
+      timestamp.put(ROCKSET_TYPE, "timestamp");
+      timestamp.put(ROCKSET_VALUE, instantToTimestamp((Instant) doc));
+      return timestamp;
+    } else if (doc instanceof LocalDateTime) {
+      // toString outputs in ISO-8601 format:
+      // uuuu-MM-dd'T'HH:mm
+      // uuuu-MM-dd'T'HH:mm:ss
+      // uuuu-MM-dd'T'HH:mm:ss.SSS
+      // uuuu-MM-dd'T'HH:mm:ss.SSSSSS
+      // uuuu-MM-dd'T'HH:mm:ss.SSSSSSSSS
+      return constructDateTime(((LocalDateTime) doc).toString());
+    } else if (doc instanceof LocalDate) {
+      // toString outputs in ISO-8601 format uuuu-MM-dd
+      return constructDate(((LocalDate) doc).toString());
+    } else if (doc instanceof LocalTime) {
+      // toString outputs in ISO-8601 format:
+      // HH:mm
+      // HH:mm:ss
+      // HH:mm:ss.SSS
+      // HH:mm:ss.SSSSSS
+      // HH:mm:ss.SSSSSSSSS
+      return constructTime(((LocalTime) doc).toString());
+    } else if (doc instanceof Timestamp) {
+      // Timestamp toString formats to yyyy-mm-dd hh:mm:ss.fffffffff format,
+      // so to use uuuu-MM-dd'T'HH:mm:ss.SSSSSSSSS notation, convert
+      // to LocalDateTime first
+      return constructDateTime(((Timestamp) doc).toLocalDateTime().toString());
+    } else if (doc instanceof Date) {
+      // Formats a date in the date escape format yyyy-mm-dd
+      return constructDate(((Date) doc).toString());
+    } else if (doc instanceof Time) {
+      // Formats a String in hh:mm:ss format
+      return constructTime(((Time) doc).toString());
     }
 
-    Object buildRocksetObject(Object doc) {
-        if (doc instanceof Map) {
-            final Map<String, Object> map = (Map) doc;
-            for (Map.Entry<String, Object> entry : map.entrySet()) {
-                Object value = buildRocksetObject(entry.getValue());
-                map.put(entry.getKey(), value);
-            }
-            return map;
-        } else if (doc instanceof List) {
-            final List<Object> list = (List) doc;
-            for (int i = 0; i < list.size(); i++) {
-                list.set(i, buildRocksetObject(list.get(i)));
-            }
-            return list;
-        } else if (doc instanceof Instant) {
-            Map<String, Object> timestamp = new HashMap<>();
-            timestamp.put(ROCKSET_TYPE, "timestamp");
-            timestamp.put(ROCKSET_VALUE, instantToTimestamp((Instant) doc));
-            return timestamp;
-        } else if (doc instanceof LocalDateTime) {
-           Map<String, Object> datetime = new HashMap<>();
-           datetime.put(ROCKSET_TYPE, "datetime");
-           // toString outputs in ISO-8601 format:
-            // uuuu-MM-dd'T'HH:mm
-            // uuuu-MM-dd'T'HH:mm:ss
-            // uuuu-MM-dd'T'HH:mm:ss.SSS
-            // uuuu-MM-dd'T'HH:mm:ss.SSSSSS
-            // uuuu-MM-dd'T'HH:mm:ss.SSSSSSSSS
-            datetime.put(ROCKSET_VALUE, ((LocalDateTime) doc).toString());
-           return datetime;
-        } else if (doc instanceof LocalDate) {
-            Map<String, Object> date = new HashMap<>();
-            date.put(ROCKSET_TYPE, "date");
-            // toString outputs in ISO-8601 format uuuu-MM-dd
-            date.put(ROCKSET_VALUE, ((LocalDate) doc).toString());
-            return date;
-        } else if (doc instanceof LocalTime) {
-            Map<String, Object> time = new HashMap<>();
-            time.put(ROCKSET_TYPE, "time");
-            // toString outputs in ISO-8601 format:
-            // HH:mm
-            // HH:mm:ss
-            // HH:mm:ss.SSS
-            // HH:mm:ss.SSSSSS
-            // HH:mm:ss.SSSSSSSSS
-            time.put(ROCKSET_VALUE, ((LocalTime) doc).toString());
-            return time;
-        }
+    return doc;
+  }
 
-        return doc;
-    }
+  private Map<String, Object> constructDateTime(String datetimeStr) {
+    Map<String, Object> datetime = new HashMap<>();
+    datetime.put(ROCKSET_TYPE, "datetime");
+    datetime.put(ROCKSET_VALUE, datetimeStr);
+    return datetime;
+  }
 
-    private long instantToTimestamp(Instant instant) {
-        return TimeUnit.SECONDS.toMicros(instant.getEpochSecond())
-                + TimeUnit.NANOSECONDS.toMicros(instant.getNano());
-    }
+  private Map<String, Object> constructDate(String dateStr) {
+    Map<String, Object> date = new HashMap<>();
+    date.put(ROCKSET_TYPE, "date");
+    date.put(ROCKSET_VALUE, dateStr);
+    return date;
+  }
+
+  private Map<String, Object> constructTime(String timeStr) {
+    Map<String, Object> time = new HashMap<>();
+    time.put(ROCKSET_TYPE, "time");
+    time.put(ROCKSET_VALUE, timeStr);
+    return time;
+  }
+
+  private long instantToTimestamp(Instant instant) {
+    return TimeUnit.SECONDS.toMicros(instant.getEpochSecond())
+        + TimeUnit.NANOSECONDS.toMicros(instant.getNano());
+  }
 }

--- a/src/main/java/com/rockset/examples/AddDocumentExample.java
+++ b/src/main/java/com/rockset/examples/AddDocumentExample.java
@@ -5,6 +5,8 @@ import com.rockset.client.model.AddDocumentsRequest;
 import com.rockset.client.model.AddDocumentsResponse;
 import com.rockset.client.model.CreateCollectionRequest;
 import com.rockset.client.model.CreateCollectionResponse;
+import java.time.Instant;
+import java.time.LocalDate;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.Map;
@@ -19,6 +21,8 @@ public class AddDocumentExample {
     Map<String, Object> json = new LinkedHashMap<>();
     json.put("name", "foo");
     json.put("address", "bar");
+    json.put("dob", LocalDate.of(2000, 7, 4));
+    json.put("_event_time", Instant.ofEpochSecond(1000));
     list.add(json);
 
     AddDocumentsRequest documentsRequest = new AddDocumentsRequest().data(list);

--- a/src/test/java/com/rockset/client/api/TestCustomDocumentsApi.java
+++ b/src/test/java/com/rockset/client/api/TestCustomDocumentsApi.java
@@ -1,0 +1,73 @@
+package com.rockset.client.api;
+
+import static org.testng.Assert.assertEquals;
+
+import com.rockset.client.ApiClient;
+import org.testng.annotations.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TestCustomDocumentsApi {
+    @Test
+    public void testConversionToRocksetObject() {
+        Map<String, Object> document = new HashMap<>();
+        document.put("bool", true);
+        document.put("int", 1);
+        document.put("long", 1L);
+        document.put("double", 1.0);
+        document.put("string", "abc");
+        document.put("null", null);
+        String s = "hello";
+        document.put("bytes", s.getBytes(StandardCharsets.UTF_8));
+        document.put("timestamp", Instant.ofEpochSecond(10));
+        document.put("datetime", LocalDateTime.of(2022, 6, 20, 12, 0, 0));
+        document.put("date", LocalDate.of(2022, 6, 21));
+        document.put("time", LocalTime.of(16, 0, 0));
+
+        List list = new ArrayList<Object>();
+        list.add("abc");
+        list.add(Instant.ofEpochSecond(10));
+        document.put("list", list);
+
+        CustomDocumentsApi documentsApi = new CustomDocumentsApi(new ApiClient());
+        documentsApi.buildRocksetObject(document);
+
+        assertEquals(document.get("bool"), true);
+        assertEquals(document.get("int"), 1);
+        assertEquals(document.get("long"), 1L);
+        assertEquals(document.get("double"), 1.0);
+        assertEquals(document.get("string"), "abc");
+        assertEquals(document.get("null"), null);
+        assertEquals(document.get("bytes"), s.getBytes(StandardCharsets.UTF_8));
+
+        Map<String, Object> timestamp = (Map) document.get("timestamp");
+        assertEquals(timestamp.get(CustomDocumentsApi.ROCKSET_TYPE), "timestamp");
+        assertEquals((long) timestamp.get(CustomDocumentsApi.ROCKSET_VALUE), 10000000);
+
+        Map<String, Object> datetime = (Map) document.get("datetime");
+        assertEquals(datetime.get(CustomDocumentsApi.ROCKSET_TYPE), "datetime");
+        assertEquals(datetime.get(CustomDocumentsApi.ROCKSET_VALUE), "2022-06-20T12:00");
+
+        Map<String, Object> date = (Map) document.get("date");
+        assertEquals(date.get(CustomDocumentsApi.ROCKSET_TYPE), "date");
+        assertEquals(date.get(CustomDocumentsApi.ROCKSET_VALUE), "2022-06-21");
+
+        Map<String, Object> time = (Map) document.get("time");
+        assertEquals(time.get(CustomDocumentsApi.ROCKSET_TYPE), "time");
+        assertEquals(time.get(CustomDocumentsApi.ROCKSET_VALUE), "16:00");
+
+        List<Object> resList = (List) document.get("list");
+        assertEquals(resList.get(0), "abc");
+        timestamp = (Map) resList.get(1);
+        assertEquals(timestamp.get(CustomDocumentsApi.ROCKSET_TYPE), "timestamp");
+        assertEquals((long) timestamp.get(CustomDocumentsApi.ROCKSET_VALUE), 10000000);
+    }
+}

--- a/src/test/java/com/rockset/client/api/TestCustomDocumentsApi.java
+++ b/src/test/java/com/rockset/client/api/TestCustomDocumentsApi.java
@@ -3,71 +3,115 @@ package com.rockset.client.api;
 import static org.testng.Assert.assertEquals;
 
 import com.rockset.client.ApiClient;
-import org.testng.annotations.Test;
-
 import java.nio.charset.StandardCharsets;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import org.testng.annotations.Test;
 
 public class TestCustomDocumentsApi {
-    @Test
-    public void testConversionToRocksetObject() {
-        Map<String, Object> document = new HashMap<>();
-        document.put("bool", true);
-        document.put("int", 1);
-        document.put("long", 1L);
-        document.put("double", 1.0);
-        document.put("string", "abc");
-        document.put("null", null);
-        String s = "hello";
-        document.put("bytes", s.getBytes(StandardCharsets.UTF_8));
-        document.put("timestamp", Instant.ofEpochSecond(10));
-        document.put("datetime", LocalDateTime.of(2022, 6, 20, 12, 0, 0));
-        document.put("date", LocalDate.of(2022, 6, 21));
-        document.put("time", LocalTime.of(16, 0, 0));
+  @Test
+  public void testConversionToRocksetObject() {
+    Map<String, Object> document = new HashMap<>();
+    document.put("bool", true);
+    document.put("int", 1);
+    document.put("long", 1L);
+    document.put("double", 1.0);
+    document.put("string", "abc");
+    document.put("null", null);
+    String s = "hello";
+    document.put("bytes", s.getBytes(StandardCharsets.UTF_8));
 
-        List list = new ArrayList<Object>();
-        list.add("abc");
-        list.add(Instant.ofEpochSecond(10));
-        document.put("list", list);
+    // java.time
+    document.put("timestamp", Instant.ofEpochSecond(10));
+    document.put("datetime", LocalDateTime.of(2022, 6, 20, 12, 0, 0));
+    document.put("date", LocalDate.of(2022, 6, 21));
+    document.put("time", LocalTime.of(16, 0, 0));
 
-        CustomDocumentsApi documentsApi = new CustomDocumentsApi(new ApiClient());
-        documentsApi.buildRocksetObject(document);
+    // java.sql
+    document.put("sql_timestamp", new Timestamp(1656417600000L));
+    document.put("sql_date", new Date(1656417600000L));
+    document.put("sql_time", new Time(1656417600000L));
 
-        assertEquals(document.get("bool"), true);
-        assertEquals(document.get("int"), 1);
-        assertEquals(document.get("long"), 1L);
-        assertEquals(document.get("double"), 1.0);
-        assertEquals(document.get("string"), "abc");
-        assertEquals(document.get("null"), null);
-        assertEquals(document.get("bytes"), s.getBytes(StandardCharsets.UTF_8));
+    List list = new ArrayList<Object>();
+    list.add("abc");
+    list.add(Instant.ofEpochSecond(10));
+    document.put("list", list);
 
-        Map<String, Object> timestamp = (Map) document.get("timestamp");
-        assertEquals(timestamp.get(CustomDocumentsApi.ROCKSET_TYPE), "timestamp");
-        assertEquals((long) timestamp.get(CustomDocumentsApi.ROCKSET_VALUE), 10000000);
+    Set set = new HashSet<Object>();
+    set.add("def");
+    set.add(Instant.ofEpochSecond(10));
+    document.put("set", set);
 
-        Map<String, Object> datetime = (Map) document.get("datetime");
-        assertEquals(datetime.get(CustomDocumentsApi.ROCKSET_TYPE), "datetime");
-        assertEquals(datetime.get(CustomDocumentsApi.ROCKSET_VALUE), "2022-06-20T12:00");
+    CustomDocumentsApi documentsApi = new CustomDocumentsApi(new ApiClient());
+    documentsApi.buildRocksetObject(document);
 
-        Map<String, Object> date = (Map) document.get("date");
-        assertEquals(date.get(CustomDocumentsApi.ROCKSET_TYPE), "date");
-        assertEquals(date.get(CustomDocumentsApi.ROCKSET_VALUE), "2022-06-21");
+    assertEquals(document.get("bool"), true);
+    assertEquals(document.get("int"), 1);
+    assertEquals(document.get("long"), 1L);
+    assertEquals(document.get("double"), 1.0);
+    assertEquals(document.get("string"), "abc");
+    assertEquals(document.get("null"), null);
+    assertEquals(document.get("bytes"), s.getBytes(StandardCharsets.UTF_8));
 
-        Map<String, Object> time = (Map) document.get("time");
-        assertEquals(time.get(CustomDocumentsApi.ROCKSET_TYPE), "time");
-        assertEquals(time.get(CustomDocumentsApi.ROCKSET_VALUE), "16:00");
+    Map<String, Object> timestamp = (Map) document.get("timestamp");
+    assertEquals(timestamp.get(CustomDocumentsApi.ROCKSET_TYPE), "timestamp");
+    assertEquals((long) timestamp.get(CustomDocumentsApi.ROCKSET_VALUE), 10000000);
 
-        List<Object> resList = (List) document.get("list");
-        assertEquals(resList.get(0), "abc");
-        timestamp = (Map) resList.get(1);
-        assertEquals(timestamp.get(CustomDocumentsApi.ROCKSET_TYPE), "timestamp");
-        assertEquals((long) timestamp.get(CustomDocumentsApi.ROCKSET_VALUE), 10000000);
+    Map<String, Object> datetime = (Map) document.get("datetime");
+    assertEquals(datetime.get(CustomDocumentsApi.ROCKSET_TYPE), "datetime");
+    assertEquals(datetime.get(CustomDocumentsApi.ROCKSET_VALUE), "2022-06-20T12:00");
+
+    Map<String, Object> date = (Map) document.get("date");
+    assertEquals(date.get(CustomDocumentsApi.ROCKSET_TYPE), "date");
+    assertEquals(date.get(CustomDocumentsApi.ROCKSET_VALUE), "2022-06-21");
+
+    Map<String, Object> time = (Map) document.get("time");
+    assertEquals(time.get(CustomDocumentsApi.ROCKSET_TYPE), "time");
+    assertEquals(time.get(CustomDocumentsApi.ROCKSET_VALUE), "16:00");
+
+    Map<String, Object> sqlTimestamp = (Map) document.get("sql_timestamp");
+    assertEquals(sqlTimestamp.get(CustomDocumentsApi.ROCKSET_TYPE), "datetime");
+    assertEquals((String) sqlTimestamp.get(CustomDocumentsApi.ROCKSET_VALUE), "2022-06-28T05:00");
+
+    Map<String, Object> sqlDate = (Map) document.get("sql_date");
+    assertEquals(sqlDate.get(CustomDocumentsApi.ROCKSET_TYPE), "date");
+    assertEquals(sqlDate.get(CustomDocumentsApi.ROCKSET_VALUE), "2022-06-28");
+
+    Map<String, Object> sqlTime = (Map) document.get("sql_time");
+    assertEquals(sqlTime.get(CustomDocumentsApi.ROCKSET_TYPE), "time");
+    assertEquals(sqlTime.get(CustomDocumentsApi.ROCKSET_VALUE), "05:00:00");
+
+    List<Object> resList = (List) document.get("list");
+    assertEquals(resList.size(), 2);
+    assertEquals(resList.get(0), "abc");
+    timestamp = (Map) resList.get(1);
+    assertEquals(timestamp.get(CustomDocumentsApi.ROCKSET_TYPE), "timestamp");
+    assertEquals((long) timestamp.get(CustomDocumentsApi.ROCKSET_VALUE), 10000000);
+
+    Set<Object> resSet = (Set<Object>) document.get("set");
+    assertEquals(resSet.size(), 2);
+    for (Object element : resSet) {
+      if (element instanceof String) {
+        assertEquals((String) element, "def");
+      } else if (element instanceof Map) {
+        Map<String, Object> setTimestamp = (Map) element;
+        assertEquals(setTimestamp.get(CustomDocumentsApi.ROCKSET_TYPE), "timestamp");
+        assertEquals((long) setTimestamp.get(CustomDocumentsApi.ROCKSET_VALUE), 10000000);
+
+      } else {
+        throw new IllegalStateException("unexpected type: " + element.getClass());
+      }
     }
+  }
 }


### PR DESCRIPTION
### Summary

Recently there was a request for docs Api on the client to infer schema (timestamp/datetime/data/time) without using query based field mappings. This adds support for it which is basically inferring `java.time` classes to convert to Rockset type object which can then be understood by our servers.

## Testing

added unit test and also tested with the `AddDocumentExample` with a rockset org/collection