### PR TITLE
_meta isn't populated anymore for file uploads

### DIFF
--- a/src/test/java/com/rockset/jdbc/TestSchema.java
+++ b/src/test/java/com/rockset/jdbc/TestSchema.java
@@ -1,6 +1,5 @@
 package com.rockset.jdbc;
 
-import static com.rockset.jdbc.TestTable.EXPECTS_META_FIELD;
 import static org.testng.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -204,9 +203,9 @@ public class TestSchema {
       uploadFile(collectionName, "src/test/resources/basic.json", null);
       waitNumberDocs(collectionName, 1);
 
-      // there should be 6 columns in this test file
-      // a, name, nested, _id, _meta, _event_time
-      final int numColumns = EXPECTS_META_FIELD ? 6 : 5;
+      // there should be 5 columns in this test file
+      // a, name, nested, _id, _event_time
+      final int numColumns = 5;
 
       conn = DriverManager.getConnection(DB_URL, property);
 

--- a/src/test/java/com/rockset/jdbc/TestSchema.java
+++ b/src/test/java/com/rockset/jdbc/TestSchema.java
@@ -1,5 +1,6 @@
 package com.rockset.jdbc;
 
+import static com.rockset.jdbc.TestTable.EXPECTS_META_FIELD;
 import static org.testng.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -205,7 +206,7 @@ public class TestSchema {
 
       // there should be 6 columns in this test file
       // a, name, nested, _id, _meta, _event_time
-      final int numColumns = 6;
+      final int numColumns = EXPECTS_META_FIELD ? 6 : 5;
 
       conn = DriverManager.getConnection(DB_URL, property);
 

--- a/src/test/java/com/rockset/jdbc/TestTable.java
+++ b/src/test/java/com/rockset/jdbc/TestTable.java
@@ -45,6 +45,9 @@ import org.testng.annotations.Test;
 //
 public class TestTable {
 
+  // whether file uploads include a _meta fields
+  static final boolean EXPECTS_META_FIELD = false;
+
   // JDBC driver name and database URL
   private static final String JDBC_DRIVER = FirstExample.JDBC_DRIVER;
   private static final String DB_URL = FirstExample.DB_URL;
@@ -206,7 +209,7 @@ public class TestTable {
 
       // there should be 6 columns in this test file
       // a, name, nested, _id, _meta, _event_time
-      final int numColumns = 6;
+      final int numColumns = EXPECTS_META_FIELD ? 6 : 5;
 
       conn = DriverManager.getConnection(DB_URL, property);
 
@@ -336,7 +339,9 @@ public class TestTable {
 
       assertNextEquals(rs, "_event_time", Types.TIMESTAMP);
       assertNextEquals(rs, "_id", Types.VARCHAR);
-      assertNextEquals(rs, "_meta", Types.JAVA_OBJECT);
+      if (EXPECTS_META_FIELD) {
+        assertNextEquals(rs, "_meta", Types.JAVA_OBJECT);
+      }
       assertNextEquals(rs, "array_col", Types.ARRAY);
       assertNextEquals(rs, "bool_col", Types.BOOLEAN);
       assertNextEquals(rs, "date_col", Types.DATE);

--- a/src/test/java/com/rockset/jdbc/TestTable.java
+++ b/src/test/java/com/rockset/jdbc/TestTable.java
@@ -45,9 +45,6 @@ import org.testng.annotations.Test;
 //
 public class TestTable {
 
-  // whether file uploads include a _meta fields
-  static final boolean EXPECTS_META_FIELD = false;
-
   // JDBC driver name and database URL
   private static final String JDBC_DRIVER = FirstExample.JDBC_DRIVER;
   private static final String DB_URL = FirstExample.DB_URL;
@@ -207,9 +204,9 @@ public class TestTable {
       uploadFile(collectionName, "src/test/resources/basic.json", null);
       waitNumberDocs(collectionName, 1);
 
-      // there should be 6 columns in this test file
-      // a, name, nested, _id, _meta, _event_time
-      final int numColumns = EXPECTS_META_FIELD ? 6 : 5;
+      // there should be 5 columns in this test file
+      // a, name, nested, _id, _event_time
+      final int numColumns = 5;
 
       conn = DriverManager.getConnection(DB_URL, property);
 
@@ -339,9 +336,6 @@ public class TestTable {
 
       assertNextEquals(rs, "_event_time", Types.TIMESTAMP);
       assertNextEquals(rs, "_id", Types.VARCHAR);
-      if (EXPECTS_META_FIELD) {
-        assertNextEquals(rs, "_meta", Types.JAVA_OBJECT);
-      }
       assertNextEquals(rs, "array_col", Types.ARRAY);
       assertNextEquals(rs, "bool_col", Types.BOOLEAN);
       assertNextEquals(rs, "date_col", Types.DATE);


### PR DESCRIPTION
Rockset no longer sets `_meta` field for file uploads. Update tests to match current Rockset backend behavior.