### PR TITLE
Tweak handling of dates

### DIFF
--- a/src/main/java/com/rockset/client/api/CustomDocumentsApi.java
+++ b/src/main/java/com/rockset/client/api/CustomDocumentsApi.java
@@ -65,10 +65,7 @@ public class CustomDocumentsApi extends DocumentsApi {
       }
       return modifiedSet;
     } else if (doc instanceof Instant) {
-      Map<String, Object> timestamp = new HashMap<>();
-      timestamp.put(ROCKSET_TYPE, "timestamp");
-      timestamp.put(ROCKSET_VALUE, instantToTimestamp((Instant) doc));
-      return timestamp;
+      return constructTimestamp((Instant) doc);
     } else if (doc instanceof LocalDateTime) {
       // toString outputs in ISO-8601 format:
       // uuuu-MM-dd'T'HH:mm
@@ -89,19 +86,26 @@ public class CustomDocumentsApi extends DocumentsApi {
       // HH:mm:ss.SSSSSSSSS
       return constructTime(((LocalTime) doc).toString());
     } else if (doc instanceof Timestamp) {
-      // Timestamp toString formats to yyyy-mm-dd hh:mm:ss.fffffffff format,
-      // so to use uuuu-MM-dd'T'HH:mm:ss.SSSSSSSSS notation, convert
-      // to LocalDateTime first
-      return constructDateTime(((Timestamp) doc).toLocalDateTime().toString());
+      return constructTimestamp(((Timestamp) doc).toInstant());
     } else if (doc instanceof Date) {
       // Formats a date in the date escape format yyyy-mm-dd
       return constructDate(((Date) doc).toString());
     } else if (doc instanceof Time) {
       // Formats a String in hh:mm:ss format
       return constructTime(((Time) doc).toString());
+    } else if (doc instanceof java.util.Date) {
+      return constructTimestamp(((java.util.Date)doc).toInstant());
+
     }
 
     return doc;
+  }
+
+  private Map<String, Object> constructTimestamp(Instant instant) {
+    Map<String, Object> timestamp = new HashMap<>();
+    timestamp.put(ROCKSET_TYPE, "timestamp");
+    timestamp.put(ROCKSET_VALUE, instantToTimestamp(instant));
+    return timestamp;
   }
 
   private Map<String, Object> constructDateTime(String datetimeStr) {

--- a/src/test/java/com/rockset/client/api/TestCustomDocumentsApi.java
+++ b/src/test/java/com/rockset/client/api/TestCustomDocumentsApi.java
@@ -40,8 +40,11 @@ public class TestCustomDocumentsApi {
 
     // java.sql
     document.put("sql_timestamp", new Timestamp(1656417600000L));
-    document.put("sql_date", new Date(1656417600000L));
-    document.put("sql_time", new Time(1656417600000L));
+    document.put("sql_date", new Date(2022-1900, 6-1, 28));
+    document.put("sql_time", new Time(5, 0, 0));
+
+    // java.util.Date
+    document.put("util_date", new java.util.Date(1656417600000L));
 
     List list = new ArrayList<Object>();
     list.add("abc");
@@ -81,8 +84,8 @@ public class TestCustomDocumentsApi {
     assertEquals(time.get(CustomDocumentsApi.ROCKSET_VALUE), "16:00");
 
     Map<String, Object> sqlTimestamp = (Map) document.get("sql_timestamp");
-    assertEquals(sqlTimestamp.get(CustomDocumentsApi.ROCKSET_TYPE), "datetime");
-    assertEquals((String) sqlTimestamp.get(CustomDocumentsApi.ROCKSET_VALUE), "2022-06-28T05:00");
+    assertEquals(sqlTimestamp.get(CustomDocumentsApi.ROCKSET_TYPE), "timestamp");
+    assertEquals((long) sqlTimestamp.get(CustomDocumentsApi.ROCKSET_VALUE), 1656417600000000L);
 
     Map<String, Object> sqlDate = (Map) document.get("sql_date");
     assertEquals(sqlDate.get(CustomDocumentsApi.ROCKSET_TYPE), "date");
@@ -91,6 +94,10 @@ public class TestCustomDocumentsApi {
     Map<String, Object> sqlTime = (Map) document.get("sql_time");
     assertEquals(sqlTime.get(CustomDocumentsApi.ROCKSET_TYPE), "time");
     assertEquals(sqlTime.get(CustomDocumentsApi.ROCKSET_VALUE), "05:00:00");
+
+    Map<String, Object> utilDate = (Map) document.get("util_date");
+    assertEquals(utilDate.get(CustomDocumentsApi.ROCKSET_TYPE), "timestamp");
+    assertEquals((long) utilDate.get(CustomDocumentsApi.ROCKSET_VALUE), 1656417600000000L);
 
     List<Object> resList = (List) document.get("list");
     assertEquals(resList.size(), 2);

--- a/src/test/java/com/rockset/client/api/TestCustomDocumentsApi.java
+++ b/src/test/java/com/rockset/client/api/TestCustomDocumentsApi.java
@@ -40,6 +40,11 @@ public class TestCustomDocumentsApi {
 
     // java.sql
     document.put("sql_timestamp", new Timestamp(1656417600000L));
+
+    // Using constructors that get time component values explicitly. The Date/Time
+    // millisecond long constructors use the time components after converting time to
+    // the default local JVM system time zone, and makes the tests sensitive to local timezone.
+    // https://docs.oracle.com/javase/7/docs/api/java/sql/Date.html#Date(long)
     document.put("sql_date", new Date(2022-1900, 6-1, 28));
     document.put("sql_time", new Time(5, 0, 0));
 


### PR DESCRIPTION
Few changes for handling dates:
* Update handling of `java.sql.Timestamp` by mapping it to Rockset's `timestamp`: `java.sql.Timestamp` represent a point in time, with nanosecond precision, so it's more appropriate to be a Rockset timestamp.
* Add support for `java.util.Date` by mapping it to Rockset's `timestamp`: Similarly `java.util.Date` represent a point in time, with millisecond precision, not a "civil time; the time that a user would see on a watch or calendar"

