### PR TITLE
Adding Types.VARCHAR -> getString() mapping in getObject.

### DIFF
--- a/src/main/java/com/rockset/jdbc/RocksetResultSet.java
+++ b/src/main/java/com/rockset/jdbc/RocksetResultSet.java
@@ -520,6 +520,8 @@ public class RocksetResultSet implements ResultSet {
     log(prefix + "getObject columnIndex " + columnIndex);
     int sqlType = resultSetMetaData.getColumnType(columnIndex);
     switch (sqlType) {
+      case java.sql.Types.VARCHAR:
+        return getString(columnIndex);
       case java.sql.Types.DATE:
         return getDate(columnIndex);
       case java.sql.Types.TIME:

--- a/src/test/java/com/rockset/jdbc/TestJdbcPreparedStatement.java
+++ b/src/test/java/com/rockset/jdbc/TestJdbcPreparedStatement.java
@@ -415,7 +415,7 @@ public class TestJdbcPreparedStatement {
     }
   }
 
-  // @Test
+  @Test
   public void testConvertVarchar() throws SQLException {
     assertParameter("hello", Types.VARCHAR, (ps, i) -> ps.setString(i, "hello"));
     assertParameter("hello", Types.VARCHAR, (ps, i) -> ps.setObject(i, "hello"));


### PR DESCRIPTION
We use Spring's [JdbcTemplate](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/jdbc/core/JdbcTemplate.html) and just added some functionality that leverages [queryForList](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/jdbc/core/JdbcTemplate.html#queryForList-java.lang.String-) to pull in arbitrary columns from collections.

We observed calling `toString()` on non-String types rendered the expected value as a string (e.g. `5` yields the equivalent of `String s = "5"`).

We observed that calling `toString` on String types rendered the expected value _wrapped in double quotes_: (e.g. "fred" yields the equivalent of `String s = "\"fred\""`).

We have implemented a simple workaround in our code - but would prefer the JDBC driver to take care of this for us:

```
private String textOrToString(Object value) {
    return switch (value) {
        case TextNode tn -> tn.textValue();
        default -> value.toString();
    };
}
```

By uncommenting the `@Test` annotation `testConvertVarchar()` and adding the mapping in `RocksetResultSet::getObject(int)`, it _looks_ like this might fix the issue?