### PR TITLE
Configure FAIL_ON_UNKNOWN_PROPERTIES for error response deserialization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -346,6 +346,12 @@
             <version>3.12.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>4.2.0</version>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
            <groupId>org.apache.commons</groupId>

--- a/src/main/java/com/rockset/client/ApiClient.java
+++ b/src/main/java/com/rockset/client/ApiClient.java
@@ -16,6 +16,7 @@ package com.rockset.client;
 import com.rockset.client.model.ErrorModel;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.squareup.okhttp.*;
 import com.squareup.okhttp.internal.http.HttpMethod;
 import com.squareup.okhttp.logging.HttpLoggingInterceptor;
@@ -53,7 +54,7 @@ import com.rockset.client.auth.HttpBasicAuth;
 
 public class ApiClient {
 
-    private String basePath = "https://api.rs2.usw2.rockset.com";
+    private String basePath = "https://api.use1a1.rockset.com";
     private String apiKey;
     private String version;
     private boolean debugging = false;
@@ -108,7 +109,7 @@ public class ApiClient {
     /**
      * Set base path
      *
-     * @param basePath Base path of the URL (e.g https://api.rs2.usw2.rockset.com
+     * @param basePath Base path of the URL (e.g https://api.use1a1.rockset.com
      * @return An instance of OkHttpClient
      */
     public ApiClient setApiServer(String basePath) {
@@ -898,6 +899,7 @@ public class ApiClient {
 
                     final ObjectMapper objectMapper = new ObjectMapper();
                     objectMapper.configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS, true);
+                    objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
                     errorModel = objectMapper.readValue(respBody, ErrorModel.class);
 
                 } catch (final IOException e) {

--- a/src/test/java/com/rockset/client/api/TestResponseMapper.java
+++ b/src/test/java/com/rockset/client/api/TestResponseMapper.java
@@ -1,0 +1,25 @@
+package com.rockset.client.api;
+
+import com.rockset.client.ApiClient;
+import com.rockset.client.ApiException;
+import com.squareup.okhttp.Response;
+import com.squareup.okhttp.ResponseBody;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestResponseMapper {
+    @Test
+    public void testUnknownProps() throws Exception {
+        ApiClient apiClient = new ApiClient();
+        Response response = Mockito.mock(Response.class);
+        Mockito.when(response.isSuccessful()).thenReturn(false);
+
+        ResponseBody body = Mockito.mock(ResponseBody.class);
+        Mockito.when(body.string()).thenReturn("{ \"message\" : \"invalid\", \"unknown_field\" : \"foo\" }");
+        Mockito.when(response.body()).thenReturn(body);
+
+        ApiException e = Assert.expectThrows(ApiException.class, () -> apiClient.handleResponse(response, null));
+        Assert.assertEquals(e.getErrorModel().getMessage(), "invalid");
+    }
+}


### PR DESCRIPTION
Address https://github.com/rockset/rockset-java-client/issues/30 (check ApiClient.java). ApiClient.java has been codegen'd from https://github.com/rockset/swagger-codegen/commit/466c6c449990c285a2b5cbd67762a1afec30a340

Added test to check error model gets deserialized correctly