### PR TITLE
Add u256 SQL Data Type Support

### DIFF
--- a/src/main/java/com/rockset/jdbc/Column.java
+++ b/src/main/java/com/rockset/jdbc/Column.java
@@ -22,7 +22,8 @@ class Column {
     DATE("DATE"),
     TIME("TIME"),
     DATETIME("DATETIME"),
-    TIMESTAMP("TIMESTAMP");
+    TIMESTAMP("TIMESTAMP"),
+    U256("U256");
 
     public static ColumnTypes fromValue(String text) {
       for (final ColumnTypes ct : ColumnTypes.values()) {

--- a/src/main/java/com/rockset/jdbc/RocksetDatabaseMetaData.java
+++ b/src/main/java/com/rockset/jdbc/RocksetDatabaseMetaData.java
@@ -815,7 +815,7 @@ public class RocksetDatabaseMetaData implements DatabaseMetaData {
       RocksetDriver.log("Exit : RocksetDatabaseMetaData getTables");
       return new RocksetResultSet(columns, data);
     } catch (Exception e) {
-      throw new SQLException("Error processing getTables " + " exception " + e.getMessage(), e);
+      throw new SQLException("Error processing getTables exception", e);
     }
   }
 
@@ -851,7 +851,7 @@ public class RocksetDatabaseMetaData implements DatabaseMetaData {
       RocksetDriver.log("Exit : RocksetDatabaseMetaData getSchemas");
       return new RocksetResultSet(columns, data);
     } catch (Exception e) {
-      throw new SQLException("Error processing getSchemas " + " exception " + e.getMessage(), e);
+      throw new SQLException("Error processing getSchemas exception", e);
     }
   }
 
@@ -875,7 +875,7 @@ public class RocksetDatabaseMetaData implements DatabaseMetaData {
       RocksetDriver.log("Exit : RocksetDatabaseMetaData getCatalogs");
       return new RocksetResultSet(columns, data);
     } catch (Exception e) {
-      throw new SQLException("Error processing getCatalogs " + " exception " + e.getMessage(), e);
+      throw new SQLException("Error processing getCatalogs exception", e);
     }
   }
 
@@ -899,7 +899,7 @@ public class RocksetDatabaseMetaData implements DatabaseMetaData {
       RocksetDriver.log("Exit : RocksetDatabaseMetaData getTableTypes");
       return new RocksetResultSet(columns, data);
     } catch (Exception e) {
-      throw new SQLException("Error processing getTableTypes " + " exception " + e.getMessage(), e);
+      throw new SQLException("Error processing getTableTypes exception", e);
     }
   }
 
@@ -936,7 +936,7 @@ public class RocksetDatabaseMetaData implements DatabaseMetaData {
       }
     } catch (Exception e) {
       e.printStackTrace();
-      throw new SQLException("Error processing getColumns " + " exception " + e.getMessage(), e);
+      throw new SQLException("Error processing getColumns exception", e);
     }
     throw new SQLException("No matching table name found.");
   }
@@ -1011,7 +1011,7 @@ public class RocksetDatabaseMetaData implements DatabaseMetaData {
       RocksetDriver.log("Exit : RocksetDatabaseMetaData getPrimaryKeys");
       return new RocksetResultSet(columns, data);
     } catch (Exception e) {
-      throw new SQLException("Error processing getPrimaryKeys " + " exception " + e.getMessage(), e);
+      throw new SQLException("Error processing getPrimaryKeys exception", e);
     }
   }
 

--- a/src/main/java/com/rockset/jdbc/RocksetDatabaseMetaData.java
+++ b/src/main/java/com/rockset/jdbc/RocksetDatabaseMetaData.java
@@ -815,7 +815,7 @@ public class RocksetDatabaseMetaData implements DatabaseMetaData {
       RocksetDriver.log("Exit : RocksetDatabaseMetaData getTables");
       return new RocksetResultSet(columns, data);
     } catch (Exception e) {
-      throw new SQLException("Error processing getTables " + " exception " + e.getMessage());
+      throw new SQLException("Error processing getTables " + " exception " + e.getMessage(), e);
     }
   }
 
@@ -851,7 +851,7 @@ public class RocksetDatabaseMetaData implements DatabaseMetaData {
       RocksetDriver.log("Exit : RocksetDatabaseMetaData getSchemas");
       return new RocksetResultSet(columns, data);
     } catch (Exception e) {
-      throw new SQLException("Error processing getSchemas " + " exception " + e.getMessage());
+      throw new SQLException("Error processing getSchemas " + " exception " + e.getMessage(), e);
     }
   }
 
@@ -875,7 +875,7 @@ public class RocksetDatabaseMetaData implements DatabaseMetaData {
       RocksetDriver.log("Exit : RocksetDatabaseMetaData getCatalogs");
       return new RocksetResultSet(columns, data);
     } catch (Exception e) {
-      throw new SQLException("Error processing getCatalogs " + " exception " + e.getMessage());
+      throw new SQLException("Error processing getCatalogs " + " exception " + e.getMessage(), e);
     }
   }
 
@@ -899,7 +899,7 @@ public class RocksetDatabaseMetaData implements DatabaseMetaData {
       RocksetDriver.log("Exit : RocksetDatabaseMetaData getTableTypes");
       return new RocksetResultSet(columns, data);
     } catch (Exception e) {
-      throw new SQLException("Error processing getTableTypes " + " exception " + e.getMessage());
+      throw new SQLException("Error processing getTableTypes " + " exception " + e.getMessage(), e);
     }
   }
 
@@ -936,7 +936,7 @@ public class RocksetDatabaseMetaData implements DatabaseMetaData {
       }
     } catch (Exception e) {
       e.printStackTrace();
-      throw new SQLException("Error processing getColumns " + " exception " + e.getMessage());
+      throw new SQLException("Error processing getColumns " + " exception " + e.getMessage(), e);
     }
     throw new SQLException("No matching table name found.");
   }
@@ -1011,7 +1011,7 @@ public class RocksetDatabaseMetaData implements DatabaseMetaData {
       RocksetDriver.log("Exit : RocksetDatabaseMetaData getPrimaryKeys");
       return new RocksetResultSet(columns, data);
     } catch (Exception e) {
-      throw new SQLException("Error processing getPrimaryKeys " + " exception " + e.getMessage());
+      throw new SQLException("Error processing getPrimaryKeys " + " exception " + e.getMessage(), e);
     }
   }
 

--- a/src/main/java/com/rockset/jdbc/RocksetDriver.java
+++ b/src/main/java/com/rockset/jdbc/RocksetDriver.java
@@ -73,7 +73,7 @@ public class RocksetDriver implements Driver, Closeable {
     try {
       uri = new URI(url);
     } catch (URISyntaxException e) {
-      throw new SQLException("Bad url format " + url + " exception " + e.getMessage());
+      throw new SQLException("Bad url format " + url + " exception", e);
     }
 
     // create a connection to the rockset service

--- a/src/main/java/com/rockset/jdbc/RocksetResultSet.java
+++ b/src/main/java/com/rockset/jdbc/RocksetResultSet.java
@@ -340,7 +340,7 @@ public class RocksetResultSet implements ResultSet {
           "Error processing getBytes for column index "
               + columnIndex
               + " exception "
-              + e.getMessage());
+              + e.getMessage(), e);
     }
   }
 
@@ -461,7 +461,7 @@ public class RocksetResultSet implements ResultSet {
           "Error processing getBytes for column label "
               + columnLabel
               + " exception "
-              + e.getMessage());
+              + e.getMessage(), e);
     }
   }
 
@@ -1400,7 +1400,7 @@ public class RocksetResultSet implements ResultSet {
       return value;
     } catch (Exception e) {
       throw new SQLException(
-          "Error processing column index " + index + " exception " + e.getMessage());
+          "Error processing column index " + index + " exception " + e.getMessage(), e);
     }
   }
 
@@ -1599,7 +1599,7 @@ public class RocksetResultSet implements ResultSet {
     } catch (Exception e) {
       log("Error processing row to extract column info " + " exception " + e.getMessage());
       throw new SQLException(
-          "Error processing row to extract column info " + " exception " + e.getMessage());
+          "Error processing row to extract column info " + " exception " + e.getMessage(), e);
     }
   }
 

--- a/src/main/java/com/rockset/jdbc/RocksetResultSet.java
+++ b/src/main/java/com/rockset/jdbc/RocksetResultSet.java
@@ -1417,7 +1417,7 @@ public class RocksetResultSet implements ResultSet {
       return value;
     } catch (Exception e) {
       throw new SQLException(
-          "Error processing column index " + index + " exception " + e.getMessage(), e);
+          "Error processing column index " + index + " exception", e);
     }
   }
 
@@ -1614,9 +1614,9 @@ public class RocksetResultSet implements ResultSet {
       }
       return out;
     } catch (Exception e) {
-      log("Error processing row to extract column info " + " exception " + e.getMessage());
+      log("Error processing row to extract column info exception" + e.getMessage());
       throw new SQLException(
-          "Error processing row to extract column info " + " exception " + e.getMessage(), e);
+          "Error processing row to extract column info exception", e);
     }
   }
 

--- a/src/main/java/com/rockset/jdbc/RocksetTable.java
+++ b/src/main/java/com/rockset/jdbc/RocksetTable.java
@@ -214,6 +214,9 @@ class RocksetTable {
       } else if (rockType.equals("geography")) {
         sqlType = Types.JAVA_OBJECT;
         sqlTypeName = "object";
+      } else if (rockType.equals("u256")) {
+        sqlType = Types.BIGINT;
+        sqlTypeName = "bigint";
       } else {
         throw new Exception("Unknown rockset type " + rockType);
       }

--- a/src/main/java/com/rockset/jdbc/RocksetUtils.java
+++ b/src/main/java/com/rockset/jdbc/RocksetUtils.java
@@ -47,6 +47,8 @@ class RocksetUtils {
       case DATE:
         stype = Types.DATE;
         break;
+      case U256:
+        stype = Types.BIGINT;
       default:
         break;
     }

--- a/src/test/java/com/rockset/jdbc/TestTable.java
+++ b/src/test/java/com/rockset/jdbc/TestTable.java
@@ -351,6 +351,7 @@ public class TestTable {
       assertNextEquals(rs, "string_col", Types.VARCHAR);
       assertNextEquals(rs, "time_col", Types.TIME);
       assertNextEquals(rs, "timestamp_col", Types.TIMESTAMP);
+      assertNextEquals(rs, "u256_col", Types.BIGINT);
       assertFalse(rs.next());
 
     } finally {

--- a/src/test/resources/types.json
+++ b/src/test/resources/types.json
@@ -10,7 +10,8 @@
   "date_col":     {"__rockset_type": "date",      "value": "2020/03/02" },
   "datetime_col": {"__rockset_type": "datetime",  "value": "2020/03/02T10:49:33"},
   "time_col":     {"__rockset_type": "time",      "value": "08:08:28.615226"},
-  "timestamp_col":{"__rockset_type": "timestamp", "value": 1584691545374000}
+  "timestamp_col":{"__rockset_type": "timestamp", "value": 1584691545374000},
+  "u256_col":     {"__rockset_type": "U256", "value": "1584691545374000"}
 }
 {
   "_id": "2",


### PR DESCRIPTION
**Summary**
- Adds support for handling a [u256 data type](https://rockset.com/docs/data-types/#u256) from a query result and in the table column types
- Includes throwable in places where SQLExceptions were thrown to help debug

**Testing**
Tested queries locally 
```
SELECT U256_FROM_BASE('d41606971632c7d11a1a612b4bfe414a', 16) as result;
281910699302070152942603136075661459786

SELECT U256_FROM_BASE('111', 10) as result;
111

SELECT U256_FROM_BASE('111', 2) as result;
7
```

Added unit test for getting table column types