### PR TITLE
Update ErrorModel swagger to fix ErrorModel enum deserialization

### DIFF
--- a/src/main/java/com/rockset/client/model/ErrorModel.java
+++ b/src/main/java/com/rockset/client/model/ErrorModel.java
@@ -31,13 +31,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 
 @ApiModel(description = "Describes details about an error")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-04-16T12:14:16.934-04:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-10-17T16:15:03.867-07:00")
 public class ErrorModel {
   @SerializedName("message")
   private String message = null;
 
   /**
-   * category of the error
+   * Category of the error.
    */
   @JsonAdapter(TypeEnum.Adapter.class)
   public enum TypeEnum {
@@ -104,6 +104,7 @@ public class ErrorModel {
       return String.valueOf(value);
     }
 
+    @com.fasterxml.jackson.annotation.JsonCreator
     public static TypeEnum fromValue(String text) {
       for (TypeEnum b : TypeEnum.values()) {
         if (String.valueOf(b.value).equals(text)) {
@@ -151,12 +152,12 @@ public class ErrorModel {
   }
 
    /**
-   * descriptive message about the error
+   * Descriptive message about the error.
    * @return message
   **/
 
 @JsonProperty("message")
-@ApiModelProperty(example = "collection not found", value = "descriptive message about the error")
+@ApiModelProperty(example = "collection not found", value = "Descriptive message about the error.")
   public String getMessage() {
     return message;
   }
@@ -171,12 +172,12 @@ public class ErrorModel {
   }
 
    /**
-   * category of the error
+   * Category of the error.
    * @return type
   **/
 
 @JsonProperty("type")
-@ApiModelProperty(example = "InvalidInput", value = "category of the error")
+@ApiModelProperty(example = "INVALIDINPUT", value = "Category of the error.")
   public TypeEnum getType() {
     return type;
   }
@@ -191,12 +192,12 @@ public class ErrorModel {
   }
 
    /**
-   * Line where the error happened (if applicable)
+   * Line where the error happened (if applicable).
    * @return line
   **/
 
 @JsonProperty("line")
-@ApiModelProperty(value = "Line where the error happened (if applicable)")
+@ApiModelProperty(value = "Line where the error happened (if applicable).")
   public Integer getLine() {
     return line;
   }
@@ -211,12 +212,12 @@ public class ErrorModel {
   }
 
    /**
-   * Column where the error happened (if applicable)
+   * Column where the error happened (if applicable).
    * @return column
   **/
 
 @JsonProperty("column")
-@ApiModelProperty(value = "Column where the error happened (if applicable)")
+@ApiModelProperty(value = "Column where the error happened (if applicable).")
   public Integer getColumn() {
     return column;
   }
@@ -231,12 +232,12 @@ public class ErrorModel {
   }
 
    /**
-   * Internal trace ID to help with debugging
+   * Internal trace ID to help with debugging.
    * @return traceId
   **/
 
 @JsonProperty("trace_id")
-@ApiModelProperty(value = "Internal trace ID to help with debugging")
+@ApiModelProperty(value = "Internal trace ID to help with debugging.")
   public String getTraceId() {
     return traceId;
   }
@@ -251,12 +252,12 @@ public class ErrorModel {
   }
 
    /**
-   * ID of the error
+   * ID of the error.
    * @return errorId
   **/
 
 @JsonProperty("error_id")
-@ApiModelProperty(value = "ID of the error")
+@ApiModelProperty(value = "ID of the error.")
   public String getErrorId() {
     return errorId;
   }
@@ -271,12 +272,12 @@ public class ErrorModel {
   }
 
    /**
-   * ID of the query (if applicable)
+   * ID of the query (if applicable).
    * @return queryId
   **/
 
 @JsonProperty("query_id")
-@ApiModelProperty(value = "ID of the query (if applicable)")
+@ApiModelProperty(value = "ID of the query (if applicable).")
   public String getQueryId() {
     return queryId;
   }

--- a/src/test/java/com/rockset/client/api/TestResponseMapper.java
+++ b/src/test/java/com/rockset/client/api/TestResponseMapper.java
@@ -1,7 +1,10 @@
 package com.rockset.client.api;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.rockset.client.ApiClient;
 import com.rockset.client.ApiException;
+import com.rockset.client.model.ErrorModel;
 import com.squareup.okhttp.Response;
 import com.squareup.okhttp.ResponseBody;
 import org.mockito.Mockito;
@@ -21,5 +24,26 @@ public class TestResponseMapper {
 
         ApiException e = Assert.expectThrows(ApiException.class, () -> apiClient.handleResponse(response, null));
         Assert.assertEquals(e.getErrorModel().getMessage(), "invalid");
+    }
+
+    @Test
+    public void testQueryError() throws Exception {
+        // Set up error response
+        ErrorModel error = new ErrorModel().message("Field `abc` not found.").type(ErrorModel.TypeEnum.QUERY_ERROR).line(1).column(15);
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
+        String errorStr = mapper.writeValueAsString(error);
+
+        ResponseBody body = Mockito.mock(ResponseBody.class);
+        Mockito.when(body.string()).thenReturn(errorStr);
+
+        Response response = Mockito.mock(Response.class);
+        Mockito.when(response.isSuccessful()).thenReturn(false);
+        Mockito.when(response.body()).thenReturn(body);
+
+        // Check deserialization
+        ApiClient apiClient = new ApiClient();
+        ApiException e = Assert.expectThrows(ApiException.class, () -> apiClient.handleResponse(response, null));
+        Assert.assertEquals(e.getErrorModel(), error);
     }
 }


### PR DESCRIPTION
Updates the code generated file for ErrorModel.java. This adds a @JsonCreator annotation on the toString method, which allows the values to be correctly deserialized from the enum value instead of the name.

This annotation is added onto many other enums, but they have not been added in this PR because there are multiple breaking changes. This solution replaces https://github.com/rockset/swagger-codegen/pull/2 and addresses https://github.com/rockset/rockset-java-client/issues/37