### PR TITLE
Prepare for release 0.9.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>rockset-java</artifactId>
     <packaging>jar</packaging>
     <name>Rockset Java</name>
-    <version>0.9.5</version>
+    <version>0.9.6-SNAPSHOT</version>
     <url>https://github.com/rockset/rockset-java-client</url>
     <description>The official Rockset Java client library</description>
     <scm>


### PR DESCRIPTION
Prevents local built JARs from conflicting with released versions.