### PR TITLE
Patch time parsing errors.

### DIFF
--- a/src/test/java/com/rockset/jdbc/TestJdbcPreparedStatement.java
+++ b/src/test/java/com/rockset/jdbc/TestJdbcPreparedStatement.java
@@ -97,6 +97,40 @@ public class TestJdbcPreparedStatement {
   }
 
   @Test
+  public void testExecuteTimeQuery() throws Exception {
+    // from console:
+    // 1 select cast('12:34' as time)    -> __rockset_type= 'TIME' / value = '12:34:00'
+    // 2 select cast('12:34:56' as time) -> __rockset_type= 'TIME' / value = '12:34:56'
+    // 3 select cast('12:34:56.1' as time) -> __rockset_type= 'TIME' / value = '12:34:56.1'
+    // 4 select cast('12:34:56.123' as time) -> __rockset_type= 'TIME' / value = '12:34:56.123'
+    // 5 select cast('12:34:56.123456' as time) -> __rockset_type= 'TIME' / value = '12:34:56.123456'
+    // 6 select cast('12:34:56.1234567890' as time) -> __rockset_type= 'TIME' / value = '12:34:56.123456'
+
+    String sql = "SELECT CAST(:1 AS TIME), CAST(:2 AS TIME), CAST(:3 AS TIME), CAST(:4 AS TIME), CAST(:5 AS TIME), CAST(:6 AS TIME)";
+
+    try (Connection connection = createConnection();
+         PreparedStatement statement = connection.prepareStatement(sql)) {
+      statement.setString(1, "12:34");
+      statement.setString(2, "12:34:56");
+      statement.setString(3,  "12:34:56.1");
+      statement.setString(4, "12:34:56.123");
+      statement.setString(5, "12:34:56.123456");
+      statement.setString(6, "12:34:56.1234567890");
+
+      try (ResultSet rs = statement.executeQuery()) {
+        assertTrue(rs.next());
+        assertEquals(rs.getTime(1), Time.valueOf("12:34:00"));
+        assertEquals(rs.getTime(2), Time.valueOf("12:34:56"));
+        assertEquals(rs.getTime(3), Time.valueOf("12:34:56"));
+        assertEquals(rs.getTime(4), Time.valueOf("12:34:56"));
+        assertEquals(rs.getTime(5), Time.valueOf("12:34:56"));
+        assertEquals(rs.getTime(6), Time.valueOf("12:34:56"));
+        assertFalse(rs.next());
+      }
+    }
+  }
+
+  @Test
   public void testExecuteQuery() throws Exception {
     String sql = "SELECT :1, :2";
 


### PR DESCRIPTION
We were seeing errors in our logs such as `Invalid time from server: 20:06:01.434197`.

After some experimentation, we observed that the JDBC driver just calls `java.sql.Time.valueOf(String)` was being called. This method explicitly expects a string of the format:

```
     * @param s time in format "hh:mm:ss"
```

When running a few cast queries through the rockset console, we observed that:

```
    // from console:
    // 1 select cast('12:34' as time)    -> __rockset_type= 'TIME' / value = '12:34:00'
    // 2 select cast('12:34:56' as time) -> __rockset_type= 'TIME' / value = '12:34:56'
    // 3 select cast('12:34:56.1' as time) -> __rockset_type= 'TIME' / value = '12:34:56.1'
    // 4 select cast('12:34:56.123' as time) -> __rockset_type= 'TIME' / value = '12:34:56.123'
    // 5 select cast('12:34:56.123456' as time) -> __rockset_type= 'TIME' / value = '12:34:56.123456'
    // 6 select cast('12:34:56.1234567890' as time) -> __rockset_type= 'TIME' / value = '12:34:56.123456'
```

Some of these will cause exceptions to bubble up from the JDBC driver.

This patch fixes the parse exceptions. I stuck with Joda vs. porting to java.time/JEP150 because I was not sure of the knock-on effort of having to move everything else over.