### PR TITLE
Move buildRocksetObject call to addCall (from add).

### DIFF
--- a/src/main/java/com/rockset/client/api/CustomDocumentsApi.java
+++ b/src/main/java/com/rockset/client/api/CustomDocumentsApi.java
@@ -1,8 +1,12 @@
 package com.rockset.client.api;
 
 import com.rockset.client.ApiClient;
+import com.rockset.client.ProgressRequestBody;
+import com.rockset.client.ProgressResponseBody;
 import com.rockset.client.model.AddDocumentsRequest;
 import com.rockset.client.model.AddDocumentsResponse;
+import com.squareup.okhttp.Call;
+
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
@@ -31,8 +35,7 @@ public class CustomDocumentsApi extends DocumentsApi {
   }
 
   @Override
-  public AddDocumentsResponse add(String workspace, String collection, AddDocumentsRequest body)
-      throws Exception {
+  public Call addCall(String workspace, String collection, AddDocumentsRequest body, ProgressResponseBody.ProgressListener progressListener, ProgressRequestBody.ProgressRequestListener progressRequestListener) throws Exception {
     for (Object doc : body.getData()) {
       if (!(doc instanceof Map)) {
         throw new IllegalArgumentException("Document is not a valid Map Object");
@@ -40,7 +43,7 @@ public class CustomDocumentsApi extends DocumentsApi {
       buildRocksetObject(doc);
     }
 
-    return super.add(workspace, collection, body);
+    return super.addCall(workspace, collection, body, progressListener, progressRequestListener);
   }
 
   Object buildRocksetObject(Object doc) {


### PR DESCRIPTION
We need to peek into the response stream so that we can pull the last_offset and wait on the fencing / we need read-after-write functionality.

We've built a shim to do this, but we also noticed that we lost JEP150/java.time type mapping into Rockset. This was because the plumbing that does this in the Java SDK happened in the add() method and we are using addCall().

It seems that add() will, eventually, call addCall() downstream.