### PR TITLE
Fix QueryLambda paginated tests

### DIFF
--- a/src/test/java/com/rockset/client/TestQueryLambda.java
+++ b/src/test/java/com/rockset/client/TestQueryLambda.java
@@ -109,7 +109,7 @@ public class TestQueryLambda {
     // Execute the QL and get only the first page.
     ExecuteQueryLambdaRequest exReq = new ExecuteQueryLambdaRequest();
     exReq.setPaginate(true);
-    exReq.setDefaultRowLimit(1);
+    exReq.setDefaultRowLimit(10);
     exReq.setInitialPaginateResponseDocCount(1);
     QueryResponse qr = client.queryLambdas.execute("commons", paginatedQueryName, queryLambdaTag, exReq);
     Assert.assertEquals(qr.getResults().size(), 1);


### PR DESCRIPTION
Fix QueryLambda paginated test. It was forever broken it seems: The Test expected 2 pages when querying a 2 record QueryLambda with a page size of 1. However, it sets a record limit of 1, so we didn't get paginated results at all.

Made other assorted changes:
* Use unique query lambda names per invocation to avoid corruption (need another process to delete dangling resources though :/ )
* Avoid relying results being `LinkedTreeMap` - that's an internal details.