### PR TITLE
Support default workspace for queries

### DIFF
--- a/src/test/java/com/rockset/client/TestWorkspace.java
+++ b/src/test/java/com/rockset/client/TestWorkspace.java
@@ -1,6 +1,8 @@
 package com.rockset.client;
 
 import com.rockset.client.model.*;
+
+import java.sql.Time;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -61,7 +63,7 @@ public class TestWorkspace {
     // wait for collection to go away
     Awaitility.await("Waiting for collection to be cleaned up ")
         .atMost(3, TimeUnit.MINUTES)
-            .pollInterval(1, TimeUnit.SECONDS)
+        .pollInterval(1, TimeUnit.SECONDS)
         .until(
             (Callable<Boolean>)
                 () -> {

--- a/src/test/java/com/rockset/client/util/RetryHelper.java
+++ b/src/test/java/com/rockset/client/util/RetryHelper.java
@@ -1,0 +1,25 @@
+package com.rockset.client.util;
+
+import com.rockset.client.ApiException;
+import org.awaitility.Awaitility;
+import org.hamcrest.Matchers;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+public class RetryHelper {
+    public static <T> T retryOnApiException(Callable<T> request) {
+        return Awaitility
+                .await()
+                .atMost(5, TimeUnit.MINUTES)
+                .pollInterval(1, TimeUnit.SECONDS)
+                .until(() -> {
+                    try {
+                        return request.call();
+                    } catch (ApiException e) {
+                        System.out.println("Encountered error, retrying request: " + e.getMessage());
+                        return null;
+                    }
+                }, Matchers.notNullValue());
+    }
+}


### PR DESCRIPTION
Allows setting a default workspace using the schema set on the JDBC connection. This makes the JDBC connector work well with tools certain tools which rely on the schema to define the workspace used for queries.