### PR TITLE
respect projection ordering in results

### DIFF
--- a/src/test/java/com/rockset/client/TestWorkspace.java
+++ b/src/test/java/com/rockset/client/TestWorkspace.java
@@ -60,7 +60,8 @@ public class TestWorkspace {
 
     // wait for collection to go away
     Awaitility.await("Waiting for collection to be cleaned up ")
-        .atMost(60, TimeUnit.SECONDS)
+        .atMost(3, TimeUnit.MINUTES)
+            .pollInterval(1, TimeUnit.SECONDS)
         .until(
             (Callable<Boolean>)
                 () -> {
@@ -70,7 +71,6 @@ public class TestWorkspace {
                   } catch (Exception e) {
                     return true; // collection deleted
                   }
-                  Thread.sleep(1000);
                   return false;
                 });
 

--- a/src/test/java/com/rockset/jdbc/TestTable.java
+++ b/src/test/java/com/rockset/jdbc/TestTable.java
@@ -6,6 +6,8 @@ import static org.testng.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import com.rockset.client.RocksetClient;
 import com.rockset.client.model.Collection;
 import com.rockset.client.model.CreateCollectionRequest;
@@ -20,6 +22,7 @@ import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.Date;
 import java.sql.DriverManager;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
@@ -27,8 +30,15 @@ import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Types;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import okhttp3.MediaType;
 import okhttp3.MultipartBody;
 import okhttp3.OkHttpClient;
@@ -38,6 +48,7 @@ import okhttp3.Response;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.testng.Assert;
 import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 //
@@ -359,6 +370,86 @@ public class TestTable {
       cleanup(collections, null, conn);
     }
   }
+
+  @Test
+  public void testColumnOrdering() throws Exception {
+    List<String> collections = generateCollectionNames(/*numCollections*/ 1);
+    Connection conn = null;
+    try {
+      createCollections(collections);
+      waitCollections(collections);
+
+      String collection = collections.get(0);
+      uploadFile(collection, "src/test/resources/mixed_nulls.json", null);
+      waitNumberDocs(collection, 2);
+
+      conn = DriverManager.getConnection(DB_URL, property);
+
+
+      // id is non null in all records
+      // name is null in one of the records
+      // age is null in all the records
+      // mixed is a string or array, however we query such that string is the first non-null type in the result set
+      // the type in the column will be string
+      // When there is a single non-null field, the type should be of the first non-null field
+      Map<String, String> projectionTypes = new HashMap<>();
+      projectionTypes.put("age", "null");
+      projectionTypes.put("id", "bigint");
+      projectionTypes.put("name", "varchar");
+      projectionTypes.put("mixed", "varchar");
+
+
+      // When there is a wildcard in the projection, no ordering is guaranteed
+      String query = String.format("select * EXCEPT(_id, _meta, _event_time) from %s", collection);
+      try (PreparedStatement stmt = conn.prepareStatement(query);
+           ResultSet rs = stmt.executeQuery()) {
+
+        ResultSetMetaData rsmd = rs.getMetaData();
+        int cc = rsmd.getColumnCount();
+        while (rs.next()) {
+          Set<String> colNames = new HashSet<>();
+          for (int i = 1; i <= cc; i++) {
+            colNames.add(rsmd.getColumnName(i));
+          }
+          Assert.assertEquals(colNames, projectionTypes.keySet());
+        }
+      }
+
+      // A few permutations of projections
+      String[][] projectionOrderings = new  String[][]{
+        {"age", "name", "mixed","id" },
+        {"name", "age", "id", "mixed"},
+        {"mixed", "name", "id", "age"},
+        {"id", "name" , "mixed", "age"},
+        {"id", "age", "name", "mixed"},
+      };
+
+      for(String[] projections : projectionOrderings) {
+        List<String> expectedTypes = Arrays.stream(projections).map(projectionTypes::get).collect(Collectors.toList());
+        query = String.format("select %s, %s, %s, %s from %s ORDER BY id ASC", projections[0], projections[1], projections[2], projections[3],  collection);
+        try (PreparedStatement stmt = conn.prepareStatement(query);
+             ResultSet rs = stmt.executeQuery()) {
+
+          ResultSetMetaData rsmd = rs.getMetaData();
+          int cc = rsmd.getColumnCount();
+          List<String> colNames = new ArrayList<>();
+          List<String> colTypes = new ArrayList<>();
+          for (int i = 1; i <= cc; i++) {
+            colNames.add(rsmd.getColumnName(i));
+            colTypes.add(rsmd.getColumnTypeName(i));
+          }
+          Assert.assertEquals(colNames, Lists.newArrayList(projections));
+          Assert.assertEquals(colTypes, expectedTypes);
+
+        }
+      }
+
+
+    } finally {
+      cleanup(collections, null, conn);
+    }
+  }
+
 
   private void assertNextEquals(ResultSet rs, String expectedColumnName, int expectedType)
       throws SQLException {

--- a/src/test/resources/all_nulls.json
+++ b/src/test/resources/all_nulls.json
@@ -1,0 +1,2 @@
+{"a":  null, "b":  null}
+{"a":  null, "b":  null}

--- a/src/test/resources/mixed_nulls.json
+++ b/src/test/resources/mixed_nulls.json
@@ -1,0 +1,2 @@
+{"id":  1, "name": null, "age": null, "mixed": "hello"  }
+{"id":  2, "name": "bob", "age": null, "mixed": ["a", "b"] }


### PR DESCRIPTION
Ensures when explicit projects are used, the returned result set is ordered as the projections are.
