### PR TITLE
Column order issue fix - in case of null values in result

### DIFF
--- a/src/main/java/com/rockset/jdbc/RocksetResultSet.java
+++ b/src/main/java/com/rockset/jdbc/RocksetResultSet.java
@@ -1623,7 +1623,7 @@ public class RocksetResultSet implements ResultSet {
           fieldNameToCol.put(field.getName(), c);
         }
       }
-      return colNamesInOrder.stream().map(fieldNameToCol::get).collect(Collectors.toList());
+      return colNamesInOrder.stream().map(fieldNameToCol::get).filter(Objects::nonNull).collect(Collectors.toList());
     } catch (Exception e) {
       log("Error processing row to extract column info exception" + e.getMessage());
       throw new SQLException(


### PR DESCRIPTION
**com.rockset.jdbc.RocksetResultSet#getColumns**
in the above method, we are trying to get the columns (field_name, value & type) from the result set.
it parses every rows one by one, for the below example

```
1, null, 20
2, ksk, 27
```
at the end of 1st row, in the columns list, we have id, age (name is skipped because of null value)
at the end of 2nd row, rockset is adding name to the column list, now the list becomes as id, age, name instead of id, name, age
**this list of columns are the resultset meta data for hibernate layer, with this metadata  hibernate puts age in the place of name**

Solution :
Tracking the order of column names in a separate list & returning the list of column object in the same order of column names list.

Additionally, i noticed a `new ObjectMapper()` is triggered for every response from rockset - [which is very expensive ](https://www.baeldung.com/jackson-json-node-tree-model#:~:text=The%20first%20step%20in%20the,same%20one%20for%20multiple%20operations.)
Since ObjectMapper is a completely threadsafe class, making it as static.

